### PR TITLE
hotfix

### DIFF
--- a/packages/lib/src/form-fields/multisearch/multisearch.wc.svelte
+++ b/packages/lib/src/form-fields/multisearch/multisearch.wc.svelte
@@ -364,7 +364,7 @@
           const res = await service.getSingle(el);
 
           if (res) {
-            single = await service.getSingle(el);
+            single = res;
             single.selected = true;
           } else {
             single = { value: el, selected: true };


### PR DESCRIPTION
in webshop template getSignle() being called 2 times results in same value being selected 2 times